### PR TITLE
Add optional shared reviewers for CableLabs

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -109,6 +109,14 @@ groups:
       teams: [reviewers-comcast]
     reviews:
       request: 0 # Do not auto-add
+  shared-reviewers-cablelabs:
+    type: optional
+    conditions:
+      - files.include('*')
+    reviewers:
+      teams: [reviewers-cablelabs]
+    reviews:
+      request: 0 # Do not auto-add
   shared-reviewers-dyson:
     type: optional
     conditions:


### PR DESCRIPTION
#### Summary

Adding Cable Labs as reviewers.


#### Testing
CI/PullApprove will validate this
